### PR TITLE
Fix deprecated accent color

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,18 +11,19 @@ void main() => runApp(MyApp());
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = ThemeData(
+        brightness: Brightness.light, primaryColor: Colors.lightGreen);
+
+    final ThemeData darkTheme =
+        ThemeData(brightness: Brightness.dark, primaryColor: Colors.lightGreen);
+
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Osallistujien arvonta',
-      theme: ThemeData(
-          brightness: Brightness.light,
-          primaryColor: Colors.lightGreen,
-          accentColor: Colors.white),
-      // Provide light theme
-      darkTheme: ThemeData(
-          brightness: Brightness.dark,
-          primaryColor: Colors.lightGreen,
-          accentColor: Colors.black),
+      theme: theme.copyWith(
+          colorScheme: theme.colorScheme.copyWith(secondary: Colors.white)),
+      darkTheme: darkTheme.copyWith(
+          colorScheme: darkTheme.colorScheme.copyWith(secondary: Colors.black)),
       home: MyHomePage(title: 'Osallistujien arvonta'),
     );
   }
@@ -76,7 +77,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
     EmojiAlert(
         emojiType: EMOJI_TYPE.WINK,
-        background: Theme.of(context).accentColor,
+        background: Theme.of(context).colorScheme.secondary,
         enableMainButton: true,
         mainButtonText: Text('Sulje'),
         mainButtonColor: Theme.of(context).primaryColor,
@@ -152,6 +153,7 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
+        backgroundColor: Theme.of(context).primaryColor,
         title: Text(widget.title),
         actions: [
           IconButton(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   audioplayers:
     dependency: "direct main"
     description:
@@ -35,7 +35,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   circular_countdown_timer:
     dependency: "direct main"
     description:
@@ -148,7 +148,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -307,7 +307,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
- Fix deprecated 'accentColor' error (based on Flutter's breaking changes -> migration guide)
- Auto-update pubspec.lock (some version numbers)

